### PR TITLE
Public key derivation. Closes #8

### DIFF
--- a/src/main/java/io/github/novacrypto/bip32/ByteArrayWriter.java
+++ b/src/main/java/io/github/novacrypto/bip32/ByteArrayWriter.java
@@ -21,6 +21,8 @@
 
 package io.github.novacrypto.bip32;
 
+import java.util.Arrays;
+
 final class ByteArrayWriter {
 
     private final byte[] bytes;
@@ -41,6 +43,7 @@ final class ByteArrayWriter {
 
     /**
      * ser32(i): serialize a 32-bit unsigned integer i as a 4-byte sequence, most significant byte first.
+     *
      * @param i a 32-bit unsigned integer
      */
     void concatSer32(final int i) {
@@ -52,5 +55,16 @@ final class ByteArrayWriter {
 
     void concat(final byte b) {
         bytes[idx++] = b;
+    }
+
+
+    static byte[] tail32(final byte[] bytes64) {
+        final byte[] ir = new byte[bytes64.length - 32];
+        System.arraycopy(bytes64, 32, ir, 0, ir.length);
+        return ir;
+    }
+
+    static byte[] head32(final byte[] bytes64) {
+        return Arrays.copyOf(bytes64, 32);
     }
 }

--- a/src/main/java/io/github/novacrypto/bip32/CKDpriv.java
+++ b/src/main/java/io/github/novacrypto/bip32/CKDpriv.java
@@ -21,17 +21,13 @@
 
 package io.github.novacrypto.bip32;
 
-import org.junit.Test;
+public interface CKDpriv {
 
-public final class ConstructorCoverage {
-
-    @Test
-    public void coverUtilClassConstructors() {
-        new BigIntegerUtils();
-        new Hash160();
-        new HmacSha512();
-        new Index();
-        new Secp256k1BC();
-        new Sha256();
-    }
+    /**
+     * Calculates the private key of the child at index.
+     *
+     * @param index The child index to calculate.
+     * @return The private key of the child.
+     */
+    PrivateKey cKDpriv(final int index);
 }

--- a/src/main/java/io/github/novacrypto/bip32/CKDpub.java
+++ b/src/main/java/io/github/novacrypto/bip32/CKDpub.java
@@ -21,17 +21,13 @@
 
 package io.github.novacrypto.bip32;
 
-import org.junit.Test;
+public interface CKDpub {
 
-public final class ConstructorCoverage {
-
-    @Test
-    public void coverUtilClassConstructors() {
-        new BigIntegerUtils();
-        new Hash160();
-        new HmacSha512();
-        new Index();
-        new Secp256k1BC();
-        new Sha256();
-    }
+    /**
+     * Calculates the public key of the child at index.
+     *
+     * @param index The child index to calculate.
+     * @return The public key of the child.
+     */
+    PublicKey cKDpub(final int index);
 }

--- a/src/main/java/io/github/novacrypto/bip32/Derivation.java
+++ b/src/main/java/io/github/novacrypto/bip32/Derivation.java
@@ -21,7 +21,7 @@
 
 package io.github.novacrypto.bip32;
 
-import static io.github.novacrypto.bip32.PrivateKey.hard;
+import static io.github.novacrypto.bip32.Index.hard;
 
 final class Derivation<T> {
 

--- a/src/main/java/io/github/novacrypto/bip32/IllegalCPKCall.java
+++ b/src/main/java/io/github/novacrypto/bip32/IllegalCPKCall.java
@@ -21,17 +21,8 @@
 
 package io.github.novacrypto.bip32;
 
-import org.junit.Test;
-
-public final class ConstructorCoverage {
-
-    @Test
-    public void coverUtilClassConstructors() {
-        new BigIntegerUtils();
-        new Hash160();
-        new HmacSha512();
-        new Index();
-        new Secp256k1BC();
-        new Sha256();
+public final class IllegalCPKCall extends RuntimeException {
+    IllegalCPKCall(final String message) {
+        super(message);
     }
 }

--- a/src/main/java/io/github/novacrypto/bip32/Index.java
+++ b/src/main/java/io/github/novacrypto/bip32/Index.java
@@ -21,17 +21,16 @@
 
 package io.github.novacrypto.bip32;
 
-import org.junit.Test;
+public final class Index {
 
-public final class ConstructorCoverage {
+    Index() {
+    }
 
-    @Test
-    public void coverUtilClassConstructors() {
-        new BigIntegerUtils();
-        new Hash160();
-        new HmacSha512();
-        new Index();
-        new Secp256k1BC();
-        new Sha256();
+    public static int hard(final int index) {
+        return index | 0x80000000;
+    }
+
+    public static boolean hardened(final int i) {
+        return (i & 0x80000000) != 0;
     }
 }

--- a/src/main/java/io/github/novacrypto/bip32/Secp256k1BC.java
+++ b/src/main/java/io/github/novacrypto/bip32/Secp256k1BC.java
@@ -23,11 +23,8 @@ package io.github.novacrypto.bip32;
 
 import org.spongycastle.asn1.x9.X9ECParameters;
 import org.spongycastle.crypto.ec.CustomNamedCurves;
-import org.spongycastle.math.ec.ECPoint;
 
 import java.math.BigInteger;
-
-import static io.github.novacrypto.bip32.BigIntegerUtils.parse256;
 
 final class Secp256k1BC {
 
@@ -37,9 +34,16 @@ final class Secp256k1BC {
         return CURVE.getN();
     }
 
-    static byte[] point(final byte[] pBytes) {
-        final BigInteger p = parse256(pBytes);
-        final ECPoint point2 = CURVE.getG().multiply(p);
-        return point2.getEncoded(true);
+    static byte[] pointSerP(final BigInteger p) {
+        return CURVE.getG()
+                .multiply(p)
+                .getEncoded(true);
+    }
+
+    static byte[] pointSerP(final BigInteger p, final byte[] toAdd) {
+        return CURVE.getG()
+                .multiply(p)
+                .add(CURVE.getCurve().decodePoint(toAdd))
+                .getEncoded(true);
     }
 }

--- a/src/test/java/io/github/novacrypto/Bip0032WikiTestVectors/TestVector1.java
+++ b/src/test/java/io/github/novacrypto/Bip0032WikiTestVectors/TestVector1.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 import static io.github.novacrypto.Bip0032WikiTestVectors.TestVectorHelpers.assertBase58;
 import static io.github.novacrypto.Bip0032WikiTestVectors.TestVectorHelpers.createMainNetRootFromSeed;
-import static io.github.novacrypto.bip32.PrivateKey.hard;
+import static io.github.novacrypto.bip32.Index.hard;
 
 public final class TestVector1 {
 
@@ -96,12 +96,6 @@ public final class TestVector1 {
     }
 
     @Test
-    public void chain_m_0h_1_2h_private_derive() {
-        assertBase58("xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM",
-                root.derive("m/0'/1/2'"));
-    }
-
-    @Test
     public void chain_m_0h_1_2h_2_public() {
         assertBase58("xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV",
                 root
@@ -120,12 +114,6 @@ public final class TestVector1 {
                         .cKDpriv(1)
                         .cKDpriv(hard(2))
                         .cKDpriv(2));
-    }
-
-    @Test
-    public void chain_m_0h_1_2h_2_private_derive() {
-        assertBase58("xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334",
-                root.derive("m/0'/1/2'/2"));
     }
 
     @Test
@@ -149,11 +137,5 @@ public final class TestVector1 {
                         .cKDpriv(hard(2))
                         .cKDpriv(2)
                         .cKDpriv(1000000000));
-    }
-
-    @Test
-    public void chain_m_0h_1_2h_2_1000000000_private_derive() {
-        assertBase58("xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76",
-                root.derive("m/0'/1/2'/2/1000000000"));
     }
 }

--- a/src/test/java/io/github/novacrypto/Bip0032WikiTestVectors/TestVector1DeriveFromString.java
+++ b/src/test/java/io/github/novacrypto/Bip0032WikiTestVectors/TestVector1DeriveFromString.java
@@ -1,0 +1,69 @@
+/*
+ *  BIP32 library, a Java implementation of BIP32
+ *  Copyright (C) 2017 Alan Evans, NovaCrypto
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  Original source: https://github.com/NovaCrypto/BIP32
+ *  You can contact the authors via github issues.
+ */
+
+package io.github.novacrypto.Bip0032WikiTestVectors;
+
+import io.github.novacrypto.bip32.PrivateKey;
+import org.junit.Test;
+
+import static io.github.novacrypto.Bip0032WikiTestVectors.TestVectorHelpers.assertBase58;
+import static io.github.novacrypto.Bip0032WikiTestVectors.TestVectorHelpers.createMainNetRootFromSeed;
+import static org.junit.Assert.assertSame;
+
+public final class TestVector1DeriveFromString {
+
+    private final PrivateKey root = createMainNetRootFromSeed("000102030405060708090a0b0c0d0e0f");
+
+    @Test
+    public void m_private() {
+        assertSame(root, root.derive("m"));
+    }
+
+    @Test
+    public void chain_m_0h_private() {
+        assertBase58("xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
+                root.derive("m/0'"));
+    }
+
+    @Test
+    public void chain_m_0h_1_private() {
+        assertBase58("xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs",
+                root.derive("m/0'/1"));
+    }
+
+    @Test
+    public void chain_m_0h_1_2h_private() {
+        assertBase58("xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM",
+                root.derive("m/0'/1/2'"));
+    }
+
+    @Test
+    public void chain_m_0h_1_2h_2_private() {
+        assertBase58("xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334",
+                root.derive("m/0'/1/2'/2"));
+    }
+
+    @Test
+    public void chain_m_0h_1_2h_2_1000000000_private() {
+        assertBase58("xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76",
+                root.derive("m/0'/1/2'/2/1000000000"));
+    }
+}

--- a/src/test/java/io/github/novacrypto/Bip0032WikiTestVectors/TestVector1PublicDerivation.java
+++ b/src/test/java/io/github/novacrypto/Bip0032WikiTestVectors/TestVector1PublicDerivation.java
@@ -1,0 +1,88 @@
+/*
+ *  BIP32 library, a Java implementation of BIP32
+ *  Copyright (C) 2017 Alan Evans, NovaCrypto
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  Original source: https://github.com/NovaCrypto/BIP32
+ *  You can contact the authors via github issues.
+ */
+
+package io.github.novacrypto.Bip0032WikiTestVectors;
+
+import io.github.novacrypto.bip32.IllegalCPKCall;
+import io.github.novacrypto.bip32.PrivateKey;
+import io.github.novacrypto.bip32.PublicKey;
+import org.junit.Test;
+
+import static io.github.novacrypto.Bip0032WikiTestVectors.TestVectorHelpers.assertBase58;
+import static io.github.novacrypto.Bip0032WikiTestVectors.TestVectorHelpers.createMainNetRootFromSeed;
+import static io.github.novacrypto.bip32.Index.hard;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public final class TestVector1PublicDerivation {
+
+    private final PrivateKey root = createMainNetRootFromSeed("000102030405060708090a0b0c0d0e0f");
+
+    @Test
+    public void chain_m_0h_1_2h_2_public() {
+        assertBase58("xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV",
+                root
+                        .cKDpriv(hard(0))
+                        .cKDpriv(1)
+                        .cKDpub(hard(2))
+                        .cKDpub(2));
+    }
+
+    @Test
+    public void verified_on_bip32_org() {
+        assertBase58("xpub6AvUGrnEpfvJ8L7GLRkBTByQ9uBvUHp9o5VxHrFxhvzV4dSWkySpNaBoLR9FpbnwRmTa69yLHF3QfcaxbWT7gWdwws5k4dpmJvqpEuMWwnj",
+                root.derive("m/0/0").neuter());
+    }
+
+    @Test
+    public void chain_m_0_0() {
+        assertBase58(root.derive("m/0/0").neuter(),
+                root
+                        .cKDpub(0)
+                        .cKDpub(0));
+    }
+
+    @Test
+    public void chain_m_0h_0() {
+        assertBase58(root.derive("m/0'/0").neuter(),
+                root
+                        .cKDpub(hard(0))
+                        .cKDpub(0));
+    }
+
+    @Test
+    public void illegal_chain_m_0h_0h() {
+        final PublicKey key = root.cKDpub(0);
+        assertThatThrownBy(() -> key.cKDpub(hard(0)))
+                .isInstanceOf(IllegalCPKCall.class)
+                .hasMessage("Cannot derive a hardened key from a public key");
+    }
+
+    @Test
+    public void chain_m_0h_1_2h_2_1000000000_public() {
+        assertBase58(root.derive("m/0'/1/2'/2/1000000000").neuter(),
+                root
+                        .cKDpriv(hard(0))
+                        .cKDpriv(1)
+                        .cKDpub(hard(2))
+                        .cKDpub(2)
+                        .cKDpub(1000000000));
+    }
+}

--- a/src/test/java/io/github/novacrypto/Bip0032WikiTestVectors/TestVector2.java
+++ b/src/test/java/io/github/novacrypto/Bip0032WikiTestVectors/TestVector2.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 import static io.github.novacrypto.Bip0032WikiTestVectors.TestVectorHelpers.assertBase58;
 import static io.github.novacrypto.Bip0032WikiTestVectors.TestVectorHelpers.createMainNetRootFromSeed;
-import static io.github.novacrypto.bip32.PrivateKey.hard;
+import static io.github.novacrypto.bip32.Index.hard;
 
 public final class TestVector2 {
 
@@ -154,12 +154,6 @@ public final class TestVector2 {
     }
 
     @Test
-    public void chain_m_0_2147483647h_1_2147483646h_private_derive() {
-        assertBase58("xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc",
-                root.derive("m/0/2147483647'/1/2147483646'"));
-    }
-
-    @Test
     public void chain_m_0_2147483647h_1_2147483646h_2_public() {
         assertBase58("xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt",
                 root
@@ -180,12 +174,6 @@ public final class TestVector2 {
                         .cKDpriv(1)
                         .cKDpriv(hard(2147483646))
                         .cKDpriv(2));
-    }
-
-    @Test
-    public void chain_m_0_2147483647h_1_2147483646h_2_private_derive() {
-        assertBase58("xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j",
-                root.derive("m/0/2147483647'/1/2147483646'/2"));
     }
 
     @Test

--- a/src/test/java/io/github/novacrypto/Bip0032WikiTestVectors/TestVector2DeriveFromString.java
+++ b/src/test/java/io/github/novacrypto/Bip0032WikiTestVectors/TestVector2DeriveFromString.java
@@ -1,0 +1,66 @@
+/*
+ *  BIP32 library, a Java implementation of BIP32
+ *  Copyright (C) 2017 Alan Evans, NovaCrypto
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  Original source: https://github.com/NovaCrypto/BIP32
+ *  You can contact the authors via github issues.
+ */
+
+package io.github.novacrypto.Bip0032WikiTestVectors;
+
+import io.github.novacrypto.bip32.PrivateKey;
+import org.junit.Test;
+
+import static io.github.novacrypto.Bip0032WikiTestVectors.TestVectorHelpers.assertBase58;
+import static io.github.novacrypto.Bip0032WikiTestVectors.TestVectorHelpers.createMainNetRootFromSeed;
+import static org.junit.Assert.assertSame;
+
+public final class TestVector2DeriveFromString {
+
+    private final PrivateKey root = createMainNetRootFromSeed(
+            "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542"
+    );
+
+    @Test
+    public void chain_m_0_private() {
+        assertBase58("xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt",
+                root.derive("m/0"));
+    }
+
+    @Test
+    public void chain_m_0_2147483647h_private() {
+        assertBase58("xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9",
+                root.derive("m/0/2147483647'"));
+    }
+
+    @Test
+    public void chain_m_0_2147483647h_1_private() {
+        assertBase58("xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTRXSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef",
+                root.derive("m/0/2147483647'/1"));
+    }
+
+    @Test
+    public void chain_m_0_2147483647h_1_2147483646h_private() {
+        assertBase58("xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc",
+                root.derive("m/0/2147483647'/1/2147483646'"));
+    }
+
+    @Test
+    public void chain_m_0_2147483647h_1_2147483646h_2_private() {
+        assertBase58("xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j",
+                root.derive("m/0/2147483647'/1/2147483646'/2"));
+    }
+}

--- a/src/test/java/io/github/novacrypto/Bip0032WikiTestVectors/TestVector3.java
+++ b/src/test/java/io/github/novacrypto/Bip0032WikiTestVectors/TestVector3.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 import static io.github.novacrypto.Bip0032WikiTestVectors.TestVectorHelpers.assertBase58;
 import static io.github.novacrypto.Bip0032WikiTestVectors.TestVectorHelpers.createMainNetRootFromSeed;
-import static io.github.novacrypto.bip32.PrivateKey.hard;
+import static io.github.novacrypto.bip32.Index.hard;
 
 /**
  * These vectors test for the retention of leading zeros. See https://github.com/bitpay/bitcore-lib/issues/47 and

--- a/src/test/java/io/github/novacrypto/Bip0032WikiTestVectors/TestVectorHelpers.java
+++ b/src/test/java/io/github/novacrypto/Bip0032WikiTestVectors/TestVectorHelpers.java
@@ -38,6 +38,13 @@ final class TestVectorHelpers {
                         .toByteArray()).toString());
     }
 
+    static void assertBase58(ToByteArray expected,
+                             ToByteArray actual) {
+        assertBase58(base58Encode(expected
+                        .toByteArray()).toString(),
+                actual);
+    }
+
     static PrivateKey createMainNetRootFromSeed(String seed) {
         return PrivateKey.fromSeed(toArray(
                 seed

--- a/src/test/java/io/github/novacrypto/Hex.java
+++ b/src/test/java/io/github/novacrypto/Hex.java
@@ -25,7 +25,7 @@ import java.math.BigInteger;
 
 public final class Hex {
 
-    static String toHex(byte[] array) {
+    public static String toHex(byte[] array) {
         final BigInteger bi = new BigInteger(1, array);
         final String hex = bi.toString(16);
         final int paddingLength = (array.length * 2) - hex.length();

--- a/src/test/java/io/github/novacrypto/bip32/DerivationTests.java
+++ b/src/test/java/io/github/novacrypto/bip32/DerivationTests.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static io.github.novacrypto.bip32.PrivateKey.hard;
+import static io.github.novacrypto.bip32.Index.hard;
 import static org.junit.Assert.assertEquals;
 
 public final class DerivationTests {

--- a/src/test/java/io/github/novacrypto/bip32/SerializerBadDataTests.java
+++ b/src/test/java/io/github/novacrypto/bip32/SerializerBadDataTests.java
@@ -1,0 +1,79 @@
+/*
+ *  BIP32 library, a Java implementation of BIP32
+ *  Copyright (C) 2017 Alan Evans, NovaCrypto
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  Original source: https://github.com/NovaCrypto/BIP32
+ *  You can contact the authors via github issues.
+ */
+
+package io.github.novacrypto.bip32;
+
+import io.github.novacrypto.bip32.networks.Bitcoin;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public final class SerializerBadDataTests {
+
+    @Test
+    public void cantSerializeIfChainCodeIsWrongLength() {
+        final Serializer serializer = new Serializer.Builder()
+                .build();
+        assertThatThrownBy(() -> serializer.serialize(new byte[32], new byte[33]))
+                .hasMessage("Chain code must be 32 bytes");
+    }
+
+    @Test
+    public void cantSerializeIfKeyIsWrongLengthForUnNeutered() {
+        final Serializer serializer = new Serializer.Builder()
+                .neutered(false)
+                .build();
+        assertThatThrownBy(() -> serializer.serialize(new byte[33], new byte[32]))
+                .hasMessage("Key must be 32 bytes for non neutered serialization");
+    }
+
+    @Test
+    public void cantSerializeIfKeyIsWrongLengthForNeutered() {
+        final Serializer serializer = new Serializer.Builder()
+                .neutered(true)
+                .build();
+        assertThatThrownBy(() -> serializer.serialize(new byte[32], new byte[32]))
+                .hasMessage("Key must be 33 bytes for neutered serialization");
+    }
+
+    @Test
+    public void cantCreateSerializerIfDepthIsNegative() {
+        final Serializer.Builder builder = new Serializer.Builder();
+        assertThatThrownBy(() -> builder.depth(-1))
+                .hasMessage("Depth must be [0..255]");
+    }
+
+    @Test
+    public void cantCreateSerializerIfDepthIsAbove255() {
+        final Serializer.Builder builder = new Serializer.Builder();
+        assertThatThrownBy(() -> builder.depth(256))
+                .hasMessage("Depth must be [0..255]");
+    }
+
+    @Test
+    public void canCreateSerializerInAllValidDepthRanges() {
+        for (int i = 0; i <= 255; i++)
+            new Serializer.Builder()
+                    .network(Bitcoin.MAIN_NET)
+                    .depth(255)
+                    .build();
+    }
+}


### PR DESCRIPTION
Serializer checks for depth and buffer sizes
Moved derive from string tests out to own
New interfaces for CKDpub and CKDpriv